### PR TITLE
Update MoveToCloseNode method to prevent infinite navigation loops

### DIFF
--- a/GatherBuddy/AutoGather/AutoGather.Movement.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Movement.cs
@@ -78,7 +78,7 @@ namespace GatherBuddy.AutoGather
             var distance2 = gameObject.Position.DistanceToPlayer2(); // Vector2
             var x = Math.Abs(gameObject.Position.Y - Player.Position.Y); // 高度差，绝对值小于 3 为可交互范围
             
-            if (distance2 < 3.5 & x < 3)
+            if (distance2 < 3.5 && x < 3)
             {
                 var waitGP = targetItem.ItemData.IsCollectable && Player.Object.CurrentGp < GatherBuddy.Config.AutoGatherConfig.MinimumGPForCollectable;
                 waitGP |= !targetItem.ItemData.IsCollectable && Player.Object.CurrentGp < GatherBuddy.Config.AutoGatherConfig.MinimumGPForGathering;
@@ -128,7 +128,7 @@ namespace GatherBuddy.AutoGather
                     }
                 }
             }
-            else if (distance2 < Math.Max(GatherBuddy.Config.AutoGatherConfig.MountUpDistance, 5) && !Dalamud.Conditions[ConditionFlag.Diving])
+            else if (distance2 < Math.Max(GatherBuddy.Config.AutoGatherConfig.MountUpDistance, 5) && !Dalamud.Conditions[ConditionFlag.Diving]) // 使用 Vector2
             {
                 Navigate(gameObject.Position, false);
             }

--- a/GatherBuddy/AutoGather/AutoGather.Movement.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Movement.cs
@@ -74,9 +74,11 @@ namespace GatherBuddy.AutoGather
 
         private void MoveToCloseNode(IGameObject gameObject, Gatherable targetItem)
         {
-            var distance = gameObject.Position.DistanceToPlayer();
+            var distance = gameObject.Position.DistanceToPlayer(); // Vector3
+            var distance2 = gameObject.Position.DistanceToPlayer2(); // Vector2
+            var x = Math.Abs(gameObject.Position.Y - Player.Position.Y); // 高度差，绝对值小于 3 为可交互范围
             
-            if (distance < 3)
+            if (distance2 < 3.5 & x < 3)
             {
                 var waitGP = targetItem.ItemData.IsCollectable && Player.Object.CurrentGp < GatherBuddy.Config.AutoGatherConfig.MinimumGPForCollectable;
                 waitGP |= !targetItem.ItemData.IsCollectable && Player.Object.CurrentGp < GatherBuddy.Config.AutoGatherConfig.MinimumGPForGathering;
@@ -115,17 +117,18 @@ namespace GatherBuddy.AutoGather
                     }
                     else
                     {
+                        //GatherBuddy.Log.Debug($"高度差为: {x}");
                         EnqueueNodeInteraction(gameObject, targetItem);
-                        //The node could be behind a rock or a tree and not be interactable. This happened in the Endwalker, but seems not to be reproducible in the Dawntrail.
-                        //Enqueue navigation anyway, just in case.
-                        if (!Dalamud.Conditions[ConditionFlag.Diving])
-                        {
-                            TaskManager.Enqueue(() => { if (!Dalamud.Conditions[ConditionFlag.Gathering]) Navigate(gameObject.Position, false); });
-                        }
+                            //The node could be behind a rock or a tree and not be interactable. This happened in the Endwalker, but seems not to be reproducible in the Dawntrail.
+                            //Enqueue navigation anyway, just in case.
+                            if (!Dalamud.Conditions[ConditionFlag.Diving])
+                            {
+                                TaskManager.Enqueue(() => { if (!Dalamud.Conditions[ConditionFlag.Gathering]) Navigate(gameObject.Position, false); });
+                            }
                     }
                 }
             }
-            else if (distance < Math.Max(GatherBuddy.Config.AutoGatherConfig.MountUpDistance, 5) && !Dalamud.Conditions[ConditionFlag.Diving])
+            else if (distance2 < Math.Max(GatherBuddy.Config.AutoGatherConfig.MountUpDistance, 5) && !Dalamud.Conditions[ConditionFlag.Diving])
             {
                 Navigate(gameObject.Position, false);
             }

--- a/GatherBuddy/CustomInfo/FuzzyVector3.cs
+++ b/GatherBuddy/CustomInfo/FuzzyVector3.cs
@@ -6,6 +6,8 @@ using System.Numerics;
 using System.Text;
 using System.Threading.Tasks;
 using ECommons.GameHelpers;
+using static FFXIVClientStructs.FFXIV.Client.Game.Character.VfxContainer;
+using ECommons.MathHelpers;
 
 namespace GatherBuddy.CustomInfo
 {
@@ -68,6 +70,13 @@ namespace GatherBuddy.CustomInfo
         public static float DistanceToPlayer(this Vector3 vector)
         {
             var distance = Vector3.Distance(vector, Player.Object.Position);
+            return distance;
+        }
+
+        public static float DistanceToPlayer2(this Vector3 vector)
+        {
+            var vector2 = vector.ToVector2();
+            var distance = Vector2.Distance(vector2, Player.Object.Position.ToVector2());
             return distance;
         }
     }

--- a/GatherBuddy/CustomInfo/FuzzyVector3.cs
+++ b/GatherBuddy/CustomInfo/FuzzyVector3.cs
@@ -6,7 +6,6 @@ using System.Numerics;
 using System.Text;
 using System.Threading.Tasks;
 using ECommons.GameHelpers;
-using static FFXIVClientStructs.FFXIV.Client.Game.Character.VfxContainer;
 using ECommons.MathHelpers;
 
 namespace GatherBuddy.CustomInfo


### PR DESCRIPTION
Try to fix terrible infinite navigation loops.
尝试修复移动逻辑导致的无限重复寻路问题。