### PR TITLE
修改为原先的移动到采集点逻辑

### DIFF
--- a/GatherBuddy/AutoGather/AutoGather.Movement.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Movement.cs
@@ -14,8 +14,6 @@ using Dalamud.Game.ClientState.Objects.Types;
 using ECommons.Automation;
 using ECommons.DalamudServices;
 using FFXIVClientStructs.FFXIV.Client.Game.UI;
-using GatherBuddy.SeFunctions;
-using GatherBuddy.Data;
 using ECommons.MathHelpers;
 using FFXIVClientStructs.FFXIV.Client.Game.Object;
 using GatherBuddy.Enums;
@@ -30,10 +28,10 @@ namespace GatherBuddy.AutoGather
             TaskManager.Enqueue(StopNavigation);
 
             var am = ActionManager.Instance();
-            TaskManager.Enqueue(() => { if (Dalamud.Conditions[ConditionFlag.Mounted]) am->UseAction(ActionType.Mount, 0); }, "下坐骑");
+            TaskManager.Enqueue(() => { if (Dalamud.Conditions[ConditionFlag.Mounted]) am->UseAction(ActionType.GeneralAction, 23); }, "下坐骑");
 
             TaskManager.Enqueue(() => !Dalamud.Conditions[ConditionFlag.InFlight] && CanAct, 1000, "等待飞行状态取消");
-            TaskManager.Enqueue(() => { if (Dalamud.Conditions[ConditionFlag.Mounted]) am->UseAction(ActionType.Mount, 0); }, "下坐骑 2");
+            TaskManager.Enqueue(() => { if (Dalamud.Conditions[ConditionFlag.Mounted]) am->UseAction(ActionType.GeneralAction, 23); }, "下坐骑 2");
             TaskManager.Enqueue(() => !Dalamud.Conditions[ConditionFlag.Mounted] && CanAct, 1000, "等待坐骑状态取消");
             // 添加移动补偿防止其他玩家看到你浮空
             TaskManager.Enqueue(() => { if (!Dalamud.Conditions[ConditionFlag.Mounted]) Chat.Instance.ExecuteCommand($"/automove on"); }, "下坐骑补偿 3"); 
@@ -94,7 +92,7 @@ namespace GatherBuddy.AutoGather
                 var waitGP = targetItem.ItemData.IsCollectable && Player.Object.CurrentGp < config.CollectableMinGP;
                 waitGP |= !targetItem.ItemData.IsCollectable && Player.Object.CurrentGp < config.GatherableMinGP;
 
-                if (Dalamud.Conditions[ConditionFlag.Mounted] && (waitGP || GetConsumablesWithCastTime(config) > 0))
+                if (Dalamud.Conditions[ConditionFlag.Mounted]) // && (waitGP || GetConsumablesWithCastTime(config) > 0) 移除等待GP或使用物品条件，默认执行下坐骑逻辑，防止其他玩家看到你空中飞人，或是所有人叠一个位置采集
                 {
                     //Try to dismount early. It would help with nodes where it is not possible to dismount at vnavmesh's provided floor point
                     EnqueueDismount();


### PR DESCRIPTION
- 修复逻辑行为: 下坐骑 -> 自动前进 -> 交互采集点
- 原始逻辑行为: 直接寻路到采集点位置后交互采集点
- 修改原因: 可能导致其他玩家视角下人物浮空，插件用户可能会大量叠在同一位置采集
- 参考历史 Pull Requests: https://github.com/AtmoOmen/GatherBuddyReborn/pull/12